### PR TITLE
encoding fast bug fix

### DIFF
--- a/cjdns-core/src/encoding.rs
+++ b/cjdns-core/src/encoding.rs
@@ -216,8 +216,8 @@ fn read_n_bits_from_position_into_u32(data: &[u8], position: u32, bits_amount: u
         let byte_mask = 128u8 >> cur_bit_num;
         accum = accum << 1;
 
-        // use reversed bytes data to read from end by index `cur_byte_num`
-        let cur_byte = data.iter().rev().nth(cur_byte_num as usize).expect("TODO");
+        // taking current byte by `cur_byte_num` index from end of `data`
+        let cur_byte = data[data.len() - 1 - cur_byte_num as usize];
         if (cur_byte & byte_mask) == 0 {
             // if bit is 0 -> AND with "111111...11110"
             accum = accum & (!1u32);

--- a/cjdns-core/src/encoding.rs
+++ b/cjdns-core/src/encoding.rs
@@ -26,7 +26,7 @@
 //! ].to_vec();
 //!
 //! let mut serialized = serialize_forms(&input.to_vec()).unwrap();
-//! assert_eq!(serialized, [0x08, 0x0c, 0x81].to_vec());
+//! assert_eq!(serialized, [0x81, 0x0c, 0x08].to_vec());
 //! let mut deserialized = deserialize_forms(&serialized).unwrap();
 //! assert_eq!(deserialized, input);
 //! ```


### PR DESCRIPTION
We actually had invalid test results: they were reversed. Fixing bug currently with a crutch and pasting references to test cases from `cjdnsencode` js lib.