### PR TITLE
Error handling refactoring

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,6 +27,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "arrayref"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -103,6 +108,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "cjdns-admin"
 version = "0.1.0"
 dependencies = [
+ "anyhow 1.0.32 (registry+https://github.com/rust-lang/crates.io-index)",
  "bendy 0.3.2 (git+https://github.com/CJDNS-Development-Team/bendy-cjdns?tag=v0.3.2-cjdns)",
  "dirs 3.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -131,6 +137,7 @@ dependencies = [
 name = "cjdns-snode"
 version = "0.1.0"
 dependencies = [
+ "anyhow 1.0.32 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 3.0.0-beta.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.2.22 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -822,6 +829,7 @@ dependencies = [
 "checksum adler 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ee2a4ec343196209d6594e19543ae87a39f96d5534d7174822a3ad825dd6ed7e"
 "checksum adler32 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "567b077b825e468cc974f0020d4082ee6e03132512f207ef1a02fd5d00d1f32d"
 "checksum aho-corasick 0.7.10 (registry+https://github.com/rust-lang/crates.io-index)" = "8716408b8bc624ed7f65d223ddb9ac2d044c0547b6fa4b0d554f3a9540496ada"
+"checksum anyhow 1.0.32 (registry+https://github.com/rust-lang/crates.io-index)" = "6b602bfe940d21c130f3895acd65221e8a61270debe89d628b9cb4e3ccb8569b"
 "checksum arrayref 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "a4c527152e37cf757a3f78aae5a06fbeefdb07ccc535c980a3208ee3060dd544"
 "checksum arrayvec 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cff77d8686867eceff3105329d4698d96c2391c176d5d03adc90c7389162b5b8"
 "checksum autocfg 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -117,6 +117,7 @@ dependencies = [
  "serde 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.57 (registry+https://github.com/rust-lang/crates.io-index)",
  "sodiumoxide 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thiserror 1.0.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.2.22 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -131,6 +132,7 @@ dependencies = [
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "sodiumoxide 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thiserror 1.0.20 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -710,6 +712,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "thiserror"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "thiserror-impl 1.0.20 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 1.0.20 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "thread_local"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -908,6 +928,8 @@ dependencies = [
 "checksum take_mut 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f764005d11ee5f36500a149ace24e00e3da98b0158b3e2d53a7495660d3f4d60"
 "checksum tar 0.4.29 (registry+https://github.com/rust-lang/crates.io-index)" = "c8a4c1d0bee3230179544336c15eefb563cf0302955d962e456542323e8c2e8a"
 "checksum textwrap 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
+"checksum thiserror 1.0.20 (registry+https://github.com/rust-lang/crates.io-index)" = "7dfdd070ccd8ccb78f4ad66bf1982dc37f620ef696c6b5028fe2ed83dd3d0d08"
+"checksum thiserror-impl 1.0.20 (registry+https://github.com/rust-lang/crates.io-index)" = "bd80fc12f73063ac132ac92aceea36734f04a1d93c1240c6944e23a3b8841793"
 "checksum thread_local 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d40c6d1b69745a6ec6fb1ca717914848da4b44ae29d9b3080cbee91d72a69b14"
 "checksum tokio 0.2.22 (registry+https://github.com/rust-lang/crates.io-index)" = "5d34ca54d84bf2b5b4d7d31e901a8464f7b60ac145a284fba25ceb801f2ddccd"
 "checksum tokio-macros 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "f0c3acc6aa564495a0f2e1d59fab677cd7f81a19994cfc7f3ad0e64301560389"

--- a/cjdns-admin/Cargo.toml
+++ b/cjdns-admin/Cargo.toml
@@ -9,6 +9,7 @@ license = "GPL-3.0"
 description = "cjdns node admin lib & binary"
 
 [dependencies]
+anyhow = "1.0"
 bendy = { git = "https://github.com/CJDNS-Development-Team/bendy-cjdns", tag = "v0.3.2-cjdns", features = ["std", "serde"] } # bencode support
 dirs = "3.0"
 hex = "0.4"

--- a/cjdns-admin/Cargo.toml
+++ b/cjdns-admin/Cargo.toml
@@ -18,4 +18,5 @@ regex = "1.3"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sodiumoxide = "0.2"
+thiserror = "1.0"
 tokio = { version = "0.2", features = ["fs", "net", "macros"] }

--- a/cjdns-core/Cargo.toml
+++ b/cjdns-core/Cargo.toml
@@ -12,12 +12,13 @@ license = "GPL-3.0"
 description = "Inter-crate cjdns types, structs & traits"
 
 [dependencies]
+data-encoding = "2.3.0"
 hex = "0.4.2"
 lazy_static = "1.4.0"
 regex = "1.3.9"
 sodiumoxide = "0.2.5"
 libsodium-sys = "0.2.5"
-data-encoding = "2.3.0"
+thiserror = "1.0"
 
 [dev-dependencies.rand]
 version = "0.7.3"

--- a/cjdns-core/src/announcement/errors.rs
+++ b/cjdns-core/src/announcement/errors.rs
@@ -1,39 +1,28 @@
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+use thiserror::Error;
+
+#[derive(Error, Debug, Copy, Clone, PartialEq, Eq)]
 pub enum PacketError {
+    #[error("Can't instantiate AnnouncementPacket from providing data")]
     CannotInstantiatePacket,
+
+    #[error("Announcement packet has invalid signature on packet data")]
     InvalidPacketSignature,
-    CannotParsePacket(ParserError),
+
+    #[error("Can't parse packet to Announcement {0}")]
+    CannotParsePacket(#[source] ParserError),
 }
 
-impl std::fmt::Display for PacketError {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        match self {
-            PacketError::CannotInstantiatePacket => write!(f, "Can't instantiate AnnouncementPacket from providing data"),
-            PacketError::InvalidPacketSignature => write!(f, "Announcement packet has invalid signature on packet data"),
-            PacketError::CannotParsePacket(e) => write!(f, "Can't parse packet to Announcement {}", e),
-        }
-    }
-}
-
-impl std::error::Error for PacketError {}
-
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[derive(Error, Debug, Copy, Clone, PartialEq, Eq)]
 pub enum ParserError {
+    #[error("Can't parse header: {0}")]
     CannotParseHeader(&'static str),
+
+    #[error("Can't parse sender auth data: {0}")]
     CannotParseAuthData(&'static str),
+
+    #[error("Can't parse entity: {0}")]
     CannotParseEntity(&'static str),
+
+    #[error("Can't parse link state: {0}")]
     CannotParseLinkState(&'static str),
 }
-
-impl std::fmt::Display for ParserError {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        match self {
-            ParserError::CannotParseHeader(fail_reason) => write!(f, "Can't parse header: {}", fail_reason),
-            ParserError::CannotParseAuthData(fail_reason) => write!(f, "Can't parse sender auth data: {}", fail_reason),
-            ParserError::CannotParseEntity(fail_reason) => write!(f, "Can't parse entity: {}", fail_reason),
-            ParserError::CannotParseLinkState(fail_reason) => write!(f, "Can't parse link state: {}", fail_reason),
-        }
-    }
-}
-
-impl std::error::Error for ParserError {}

--- a/cjdns-core/src/encoding.rs
+++ b/cjdns-core/src/encoding.rs
@@ -39,26 +39,26 @@ use crate::EncodingSchemeForm;
 
 #[derive(Error, Debug, PartialEq, Eq)]
 pub enum EncodingSchemeError {
-    #[error("Vector passed to method is emtpy")]
-    ArgumentVectorIsEmpty,
-    #[error("Vector passed to method has too big size")]
-    ArgumentVectorSizeTooBig,
-    #[error("Vector passed to method is too small")]
-    ArgumentVectorTooSmall,
-    #[error("Numerical argument is out of bounds")]
-    ArgumentOutOfBounds,
-    #[error("Single form in scheme has non-empty prefix")]
-    SchemeNotValidNonEmptyPrefixSingleForm,
-    #[error("Form has bit_count out of bounds (from 1 to 31)")]
-    SchemeNotValidBitCountOutOfBounds,
-    #[error("Multiple forms - prefix is out of bounds (must be from 1 to 31)")]
-    SchemeNotValidPrefixLenOutOfBounds,
-    #[error("Multiple forms - bit_count must be in ascending order")]
-    SchemeNotValidBitCountNotInAscendingOrder,
-    #[error("Form size too big (bit_count + prefix_len > 59)")]
-    SchemeNotValidFormSizeTooBig,
-    #[error("Multiple forms - must have unique prefixes - found non-unique")]
-    SchemeNotValidPrefixNonUnique,
+    #[error("Invalid encoding scheme: no encoding forms defined")]
+    NoEncodingForms,
+    #[error("Invalid encoding scheme: too many encoding forms defined (max 31)")]
+    TooManyEncodingForms,
+    #[error("Invalid encoding scheme: single form has non-empty prefix")]
+    SingleFormWithPrefix,
+    #[error("Invalid encoding scheme: form has bit_count out of bounds (1..31)")]
+    BadBitCount,
+    #[error("Invalid encoding scheme: multiple forms - prefix length is out of bounds (1..31)")]
+    MultiFormBadPrefix,
+    #[error("Invalid encoding scheme: multiple forms should have bit_count in ascending order")]
+    BitCountNotSorted,
+    #[error("Invalid encoding scheme: multiple forms must have unique prefixes")]
+    DuplicatePrefix,
+    #[error("Invalid encoding scheme: form size too big (bit_count + prefix_len > 59)")]
+    TooBigForm,
+    #[error("Invalid serialized encoding scheme")]
+    BadSerializedData,
+    #[error("Invalid encoding form")]
+    BadEncodingForm,
 }
 
 type Result<T> = std::result::Result<T, EncodingSchemeError>;
@@ -72,24 +72,24 @@ pub fn form_size(form: &EncodingSchemeForm) -> u8 {
 /// Validates encoding scheme. Returned value in case of error describes the problem.
 pub fn validate(forms: &[EncodingSchemeForm]) -> Result<()> {
     if forms.len() == 0 {
-        return Err(EncodingSchemeError::ArgumentVectorIsEmpty);
+        return Err(EncodingSchemeError::NoEncodingForms);
     }
 
     if forms.len() > 31 {
         // each form must have a different prefix_len and bit_count;
         // can only be expressed in 5 bits limiting it to 31 bits max and a form
         // using zero bits is not allowed so there are only 31 max possibilities.
-        return Err(EncodingSchemeError::ArgumentVectorSizeTooBig);
+        return Err(EncodingSchemeError::TooManyEncodingForms);
     }
 
     if forms.len() == 1 {
         // if single form - prefix must be empty
         let form = forms[0];
         if form.prefix_len != 0 || form.prefix != 0 {
-            return Err(EncodingSchemeError::SchemeNotValidNonEmptyPrefixSingleForm);
+            return Err(EncodingSchemeError::SingleFormWithPrefix);
         }
         if form.bit_count == 0 || form.bit_count > 31 {
-            return Err(EncodingSchemeError::SchemeNotValidBitCountOutOfBounds);
+            return Err(EncodingSchemeError::BadBitCount);
         }
         return Ok(());
     }
@@ -100,27 +100,27 @@ pub fn validate(forms: &[EncodingSchemeForm]) -> Result<()> {
     for form in forms {
         // when multiple forms - prefixes must be non-empty
         if form.prefix_len == 0 || form.prefix_len > 31 {
-            return Err(EncodingSchemeError::SchemeNotValidPrefixLenOutOfBounds);
+            return Err(EncodingSchemeError::MultiFormBadPrefix);
         }
 
         if form.bit_count == 0 || form.bit_count > 31 {
-            return Err(EncodingSchemeError::SchemeNotValidBitCountOutOfBounds);
+            return Err(EncodingSchemeError::BadBitCount);
         }
 
         // forms must have bit_count in ascending order
         if last_bit_count > form.bit_count {
-            return Err(EncodingSchemeError::SchemeNotValidBitCountNotInAscendingOrder);
+            return Err(EncodingSchemeError::BitCountNotSorted);
         }
         last_bit_count = form.bit_count;
 
         // bit_count + prefix_len must be < 59 bits
         if form_size(form) > 59 {
-            return Err(EncodingSchemeError::SchemeNotValidFormSizeTooBig);
+            return Err(EncodingSchemeError::TooBigForm);
         }
 
         // forms must be distinguishable by their prefix
         if used_prefixes.contains(&form.prefix) {
-            return Err(EncodingSchemeError::SchemeNotValidPrefixNonUnique);
+            return Err(EncodingSchemeError::DuplicatePrefix);
         }
         used_prefixes.insert(form.prefix);
     }
@@ -133,32 +133,31 @@ pub fn validate(forms: &[EncodingSchemeForm]) -> Result<()> {
 /// and returns the result as bytes vector.
 pub fn serialize_forms(encforms: &[EncodingSchemeForm]) -> Result<Vec<u8>> {
     let mut result_vec: Vec<u8> = [].to_vec();
-    let mut pos = 0u32;
+    let mut pos = 0_u32;
     let mut cur_byte_num = 0;
-    let mut cur_bit_num = 0u8;
+    let mut cur_bit_num = 0_u8;
 
     for encform in encforms {
         // any form can be packed in u64
-        let mut accum64 = 0u64;
+        let mut acc = 0_u64;
 
-        // [TODO] fix err handling
         if encform.prefix_len > 31 {
-            return Err(EncodingSchemeError::ArgumentOutOfBounds);
+            return Err(EncodingSchemeError::BadEncodingForm);
         }
 
         if encform.bit_count < 1 || encform.bit_count > 31 {
-            return Err(EncodingSchemeError::ArgumentOutOfBounds);
+            return Err(EncodingSchemeError::BadEncodingForm);
         }
 
         if encform.prefix_len > 0 {
-            accum64 = accum64 | u64::from(encform.prefix);
+            acc = acc | encform.prefix as u64;
         }
 
-        accum64 = accum64 << 5;
-        accum64 = accum64 | u64::from(encform.bit_count);
+        acc = acc << 5;
+        acc = acc | encform.bit_count as u64;
 
-        accum64 = accum64 << 5;
-        accum64 = accum64 | u64::from(encform.prefix_len);
+        acc = acc << 5;
+        acc = acc | encform.prefix_len as u64;
 
         let bits_needed = 5 + 5 + encform.prefix_len;
         // println!("[DEBUG] accum: {:064b}", accum64);
@@ -166,38 +165,32 @@ pub fn serialize_forms(encforms: &[EncodingSchemeForm]) -> Result<Vec<u8>> {
         for _ in 0..bits_needed {
             if pos % 8 == 0 {
                 // start to work with new byte on each 8-th bit (alloc new byte in result_vec)
-                result_vec.push(0u8);
+                result_vec.push(0);
                 cur_byte_num = cur_byte_num + 1;
                 cur_bit_num = 0;
             }
-            let mask = 1u8 << cur_bit_num;
-            if (accum64 % 2) == 1 {
+            let mask = 1 << cur_bit_num;
+            if (acc % 2) == 1 {
                 result_vec[cur_byte_num - 1] = result_vec[cur_byte_num - 1] | mask;
             }
-            accum64 = accum64 >> 1;
+            acc = acc >> 1;
             cur_bit_num = cur_bit_num + 1;
             pos = pos + 1;
         }
 
-        assert_eq!(accum64, 0u64);
+        assert_eq!(acc, 0);
     }
 
     Ok(result_vec)
 }
 
-fn read_n_bits_from_position_into_u32(data: &[u8], position: u32, bits_amount: u8) -> Result<u32> {
-    // TODO check errors handling
-    if bits_amount > 32 {
-        return Err(EncodingSchemeError::ArgumentOutOfBounds);
-    }
+fn read_bits(data: &[u8], position: u32, bits_amount: u8) -> u32 {
+    assert!(bits_amount <= 32); // It is a programming error to request more than 32 bits
+    assert!(position + bits_amount as u32 <= (data.len() as u32) * 8); // Programming error to read bits beyond input buffer
 
-    if (position + (bits_amount as u32)) > ((data.len() as u32) * 8) {
-        return Err(EncodingSchemeError::ArgumentOutOfBounds);
-    }
-    let mut accum = 0u32; // maximum that can be parsed is prefix itself (max - 32 bits)
+    let mut acc = 0; // maximum that can be parsed is prefix itself (max - 32 bits)
     if bits_amount == 0 {
-        // [NOTE] reading 0 bits from any correct position returns 0x000000
-        return Ok(accum);
+        return acc; // reading 0 bits from any correct position returns 0x000000
     }
     let mut pos = position;
     let mut cur_byte_num;
@@ -209,34 +202,30 @@ fn read_n_bits_from_position_into_u32(data: &[u8], position: u32, bits_amount: u
         cur_bit_num = pos % 8;
 
         // 0000...1...0000, where "1" is on position correspondig to current bit
-        let byte_mask = 128u8 >> cur_bit_num;
-        accum = accum << 1;
+        let byte_mask = 128 >> cur_bit_num;
+        acc = acc << 1;
 
         // taking current byte by `cur_byte_num` index from end of `data`
         let cur_byte = data[data.len() - 1 - cur_byte_num as usize];
         if (cur_byte & byte_mask) == 0 {
             // if bit is 0 -> AND with "111111...11110"
-            accum = accum & (!1u32);
+            acc = acc & (!1);
         } else {
             // if bit is 1 -> OR with "00000...000001"
-            accum = accum | 1u32;
+            acc = acc | 1;
         }
         pos = pos + 1;
         bits_left = bits_left - 1;
     }
-    Ok(accum)
+    acc
 }
 
 /// Parse byte vector array (bits sequence) and transform it to encoding scheme.
 ///
 /// Accepts bytes array, parses it and returns vector of `EncodingSchemeForm`s.
 pub fn deserialize_forms(form_bytes: &[u8]) -> Result<Vec<EncodingSchemeForm>> {
-    // TODO handle errors
     if form_bytes.len() < 2 {
-        return Err(EncodingSchemeError::ArgumentVectorTooSmall);
-    }
-    if form_bytes.len() == 0 {
-        return Err(EncodingSchemeError::ArgumentVectorIsEmpty);
+        return Err(EncodingSchemeError::BadSerializedData);
     }
 
     let mut result = Vec::new();
@@ -244,15 +233,15 @@ pub fn deserialize_forms(form_bytes: &[u8]) -> Result<Vec<EncodingSchemeForm>> {
 
     loop {
         cur_pos = cur_pos - 5;
-        let prefix_len = read_n_bits_from_position_into_u32(form_bytes, cur_pos, 5).unwrap(); //TODO need proper error handling, probably redesign
+        let prefix_len = read_bits(form_bytes, cur_pos, 5);
 
         cur_pos = cur_pos - 5;
-        let bit_count = read_n_bits_from_position_into_u32(form_bytes, cur_pos, 5).unwrap(); //TODO need proper error handling, probably redesign
+        let bit_count = read_bits(form_bytes, cur_pos, 5);
 
         cur_pos = cur_pos - prefix_len;
 
-        // if prefix_len == 0 we simply read 0 bits from current position, receiving prefix = 0u32
-        let prefix = read_n_bits_from_position_into_u32(form_bytes, cur_pos, prefix_len as u8).unwrap(); //TODO need proper error handling, probably redesign
+        // if prefix_len == 0 we simply read 0 bits from current position, receiving prefix = 0
+        let prefix = read_bits(form_bytes, cur_pos, prefix_len as u8);
 
         // println!("[DEBUG] prefix: {:b}, bit_count: {:05b}, prefix_len: {:05b}", prefix, bit_count, prefix_len);
         result.push(EncodingSchemeForm {
@@ -285,27 +274,27 @@ mod tests {
         input = [
             EncodingSchemeForm { bit_count: 4, prefix_len: 1, prefix: 1 },
         ].to_vec();
-        assert_eq!(validate(&input), Err(EncodingSchemeError::SchemeNotValidNonEmptyPrefixSingleForm));
+        assert_eq!(validate(&input), Err(EncodingSchemeError::SingleFormWithPrefix));
 
         // test non-valid bit_count single form
         input = [
             EncodingSchemeForm { bit_count: 34, prefix_len: 0, prefix: 0 },
         ].to_vec();
-        assert_eq!(validate(&input), Err(EncodingSchemeError::SchemeNotValidBitCountOutOfBounds));
+        assert_eq!(validate(&input), Err(EncodingSchemeError::BadBitCount));
 
         // test non-valid bit_count multiple forms
         input = [
             EncodingSchemeForm { bit_count: 30, prefix_len: 1, prefix: 1 },
             EncodingSchemeForm { bit_count: 34, prefix_len: 2, prefix: 2 },
         ].to_vec();
-        assert_eq!(validate(&input), Err(EncodingSchemeError::SchemeNotValidBitCountOutOfBounds));
+        assert_eq!(validate(&input), Err(EncodingSchemeError::BadBitCount));
 
         // test non valid prefix_len
         input = [
             EncodingSchemeForm { bit_count: 3, prefix_len: 32, prefix: 111 },
             EncodingSchemeForm { bit_count: 4, prefix_len: 4, prefix: 2 },
         ].to_vec();
-        assert_eq!(validate(&input), Err(EncodingSchemeError::SchemeNotValidPrefixLenOutOfBounds));
+        assert_eq!(validate(&input), Err(EncodingSchemeError::MultiFormBadPrefix));
 
         // test bit_count not in ascending order
         input = [
@@ -315,14 +304,14 @@ mod tests {
             EncodingSchemeForm { bit_count: 4, prefix_len: 6, prefix: 4 },
             EncodingSchemeForm { bit_count: 8, prefix_len: 7, prefix: 5 },
         ].to_vec();
-        assert_eq!(validate(&input), Err(EncodingSchemeError::SchemeNotValidBitCountNotInAscendingOrder));
+        assert_eq!(validate(&input), Err(EncodingSchemeError::BitCountNotSorted));
 
         // test too big form size (bit_count + prefix_len > 59)
         input = [
             EncodingSchemeForm { bit_count: 3, prefix_len: 3, prefix: 1 },
             EncodingSchemeForm { bit_count: 31, prefix_len: 29, prefix: 5 },
         ].to_vec();
-        assert_eq!(validate(&input), Err(EncodingSchemeError::SchemeNotValidFormSizeTooBig));
+        assert_eq!(validate(&input), Err(EncodingSchemeError::TooBigForm));
 
         // test non-unique prefix in multiple forms
         input = [
@@ -331,7 +320,7 @@ mod tests {
             EncodingSchemeForm { bit_count: 5, prefix_len: 5, prefix: 6 },
             EncodingSchemeForm { bit_count: 8, prefix_len: 9, prefix: 2 },
         ].to_vec();
-        assert_eq!(validate(&input), Err(EncodingSchemeError::SchemeNotValidPrefixNonUnique));
+        assert_eq!(validate(&input), Err(EncodingSchemeError::DuplicatePrefix));
     }
 
     #[test]
@@ -412,7 +401,7 @@ mod tests {
     fn test_forms_pack_with_sequental_parameters() {
         // test of forms pack with different parameters
         let mut pack: Vec<EncodingSchemeForm> = [].to_vec();
-        let mut prefix = 1u32;
+        let mut prefix = 1_u32;
 
         for i in 1..30 {
             let prefix_len = i;

--- a/cjdns-core/src/keys/errors.rs
+++ b/cjdns-core/src/keys/errors.rs
@@ -1,26 +1,21 @@
-#[derive(Copy, Clone, PartialEq, Eq, Debug)]
-pub enum Error {
+use thiserror::Error;
+
+#[derive(Error, Copy, Clone, PartialEq, Eq, Debug)]
+pub enum KeyError {
+    #[error("Can not decode key string")]
     CannotDecode,
+
+    #[error("Can not create from string")]
     CannotCreateFromString,
+
+    #[error("Can not create ip6 from public key")]
     CannotCreateFromPublicKey,
+
+    #[error("Can not create from bytes")]
     CannotCreateFromBytes,
+
+    #[error("Can not parse node name")]
     CannotParseNodeName,
 }
 
-impl std::fmt::Display for Error {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        match self {
-            Error::CannotDecode => write!(f, "Can not decode key string"),
-            Error::CannotCreateFromString => write!(f, "Can not create from string"),
-            Error::CannotCreateFromPublicKey => write!(f, "Can not create ip6 from public key"),
-            Error::CannotCreateFromBytes => write!(f, "Can not create from bytes"),
-            Error::CannotParseNodeName => write!(f, "Can not parse node name"),
-        }
-    }
-}
-
-impl std::error::Error for Error {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        None
-    }
-}
+pub(super) type Result<T> = std::result::Result<T, KeyError>;

--- a/cjdns-core/src/keys/node.rs
+++ b/cjdns-core/src/keys/node.rs
@@ -5,7 +5,7 @@ use regex::Regex;
 use crate::RoutingLabel;
 
 use super::CJDNSPublicKey;
-use super::errors::Error;
+use super::errors::{KeyError, Result};
 
 lazy_static! {
     static ref NODE_NAME_RE: Regex = Regex::new(
@@ -16,7 +16,7 @@ lazy_static! {
 }
 
 /// Gets version, label and public key all together in tuple from `name` argument, if it has valid structure. Otherwise returns error.
-pub fn parse_node_name(name: String) -> Result<(u32, RoutingLabel<u64>, CJDNSPublicKey), Error> {
+pub fn parse_node_name(name: String) -> Result<(u32, RoutingLabel<u64>, CJDNSPublicKey)> {
     if let Some(c) = NODE_NAME_RE.captures(&name) {
         let str_from_captured_group = |group_num: usize| -> &str { c.get(group_num).expect("bad group index").as_str() };
         let version = str_from_captured_group(1).parse::<u32>().expect("bad regexp - version");
@@ -24,7 +24,7 @@ pub fn parse_node_name(name: String) -> Result<(u32, RoutingLabel<u64>, CJDNSPub
         let public_key = CJDNSPublicKey::try_from(str_from_captured_group(3).to_string())?;
         Ok((version, label, public_key))
     } else {
-        Err(Error::CannotParseNodeName)
+        Err(KeyError::CannotParseNodeName)
     }
 }
 

--- a/cjdns-snode/Cargo.toml
+++ b/cjdns-snode/Cargo.toml
@@ -9,5 +9,6 @@ license = "GPL-3.0"
 description = "cjdns supernode"
 
 [dependencies]
+anyhow = "1.0"
 clap = { version = "3.0.0-beta.1", default-features = false, features = [ "std", "derive" ] }
 tokio = { version = "0.2", features = ["fs", "net", "macros"] }

--- a/cjdns-snode/src/main.rs
+++ b/cjdns-snode/src/main.rs
@@ -1,8 +1,8 @@
 //! CJDNS supernode
 
-use std::error::Error;
 use std::path::{Path, PathBuf};
 
+use anyhow::Error;
 use clap::Clap;
 
 #[tokio::main]
@@ -12,9 +12,7 @@ async fn main() {
     }
 }
 
-type Err = Box<dyn Error>;
-
-async fn run() -> Result<(), Err> {
+async fn run() -> Result<(), Error> {
     let opts: Opts = Opts::parse();
     let _ = opts.config_file_path();
 


### PR DESCRIPTION
* Использование `anyhow` для application code (вместо `Box<dyn std::error::Error>`)
* Использование `thiserror` для создания типов ошибок в library code
* Рефакторинг обработки ошибок в модуле `encoding` (закрыты todo + общее причесывание)